### PR TITLE
Symfony 6 support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=8.0",
-        "symfony/config": "^5.2",
-        "symfony/form": "^5.2",
-        "symfony/framework-bundle": "^5.2"
+        "symfony/config": "^5.2 | ^6.0",
+        "symfony/form": "^5.2 | ^6.0",
+        "symfony/framework-bundle": "^5.2 | ^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
         "phpro/grumphp": "^1.3",
         "phpunit/phpunit": "^9.5",
-        "symfony/var-dumper": "^5.2"
+        "symfony/var-dumper": "^5.2 | ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have added symfony 6 in the composer.json, as far as I can see right now, this works well, without this change upgrades beyond SF5 can't be made.